### PR TITLE
Run change detection when dialog close

### DIFF
--- a/src/color-picker.directive.ts
+++ b/src/color-picker.directive.ts
@@ -1,4 +1,7 @@
-import {Component, OnChanges, Directive, Input, Output, ViewContainerRef, ElementRef, EventEmitter, OnInit, ViewChild} from '@angular/core';
+import {
+    Component, OnChanges, Directive, Input, Output, ViewContainerRef, ElementRef, EventEmitter, OnInit, ViewChild,
+    ChangeDetectorRef
+} from '@angular/core';
 import {ColorPickerService} from './color-picker.service';
 import {Rgba, Hsla, Hsva, SliderPosition, SliderDimension} from './classes';
 import {NgModule, Compiler, ReflectiveInjector} from '@angular/core';
@@ -253,7 +256,7 @@ export class DialogComponent implements OnInit {
 
     @ViewChild('dialogPopup') dialogElement: any;
 
-    constructor(private el: ElementRef, private service: ColorPickerService) { }
+    constructor(private el: ElementRef, private service: ColorPickerService, private changeDetectorRef: ChangeDetectorRef) { }
 
     setDialog(instance: any, elementRef: ElementRef, color: any, cpPosition: string, cpPositionOffset: string,
         cpPositionRelativeToArrow: boolean, cpOutputFormat: string, cpPresetLabel: string, cpPresetColors: Array<string>,
@@ -375,6 +378,8 @@ export class DialogComponent implements OnInit {
             this.directiveInstance.toggle(false);
             document.removeEventListener('mousedown', this.listenerMouseDown);
             window.removeEventListener('resize', this.listenerResize);
+
+            this.changeDetectorRef.detectChanges();
         }
     }
 


### PR DESCRIPTION
When used in a component with `changeDetection` set to `OnPush`, color-picker's template doesn't reflect changes in model. (It doesn't know `this.show` is set to `false`)